### PR TITLE
remove 0 srate warning

### DIFF
--- a/load_xdf.m
+++ b/load_xdf.m
@@ -395,8 +395,7 @@ while 1
             if temp(id).srate > 0
                 temp(id).sampling_interval = 1/temp(id).srate;
             else
-			    warning('Nominal sampling rate of stream %s is 0. Calculated effective sampling rate might not be meaningful, relying on this rate is not recommended.', header.info.name);
-                temp(id).sampling_interval = 0;
+			    temp(id).sampling_interval = 0;
             end
             % fread parsing format for data values
             temp(id).readfmt = ['*' header.info.channel_format];


### PR DESCRIPTION
This line is not correct:
https://github.com/xdf-modules/xdf-Matlab/blob/master/load_xdf.m#L398

First of all, many, many streams have a sampling rate of 0. That indicates that it is a marker stream. Second of all (and I couldn't find this in the commit history) but the tabbing is not right. No matter. I propose this line be deleted. 