### PR TITLE
add unicode support for stream meta-data

### DIFF
--- a/load_xdf.m
+++ b/load_xdf.m
@@ -377,7 +377,10 @@ while 1
             id = length(streams)+1;
             idmap(streamid) = id; 
             % read [Content]
-            header = parse_xml_struct(fread(f,len-6,'*char')');
+            data_uint = fread(f,len-6,'*uint8');
+            data = native2unicode(data_uint, 'UTF-8');
+            header = parse_xml_struct(data);
+
             if ~isfield(header.info, 'desc')
                 header.info.desc = [];
             end


### PR DESCRIPTION
Small change to enable Matlab to correctly encode unicode characters in stream meta-data. pyxdf is already capable of doing this. Many vendors require unicode support for channel labels, units, etc.